### PR TITLE
Сброс значений "скользости" на стандартные.

### DIFF
--- a/zzz_redmoon/code/game/objects/items/SoapChange.dm
+++ b/zzz_redmoon/code/game/objects/items/SoapChange.dm
@@ -1,0 +1,3 @@
+/obj/item/soap/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/slippery)


### PR DESCRIPTION
Реализация идеи из предложки:
https://discord.com/channels/1325992381899866183/1417962866224529629/1417962866224529629

(На момент написание оставило поддержку 17 человек)

Сбрасывает настройки компонента скользкости мыла (Ранее значение падения на 8 секунд) на нулевые.

Известный баг: При проходке персонажа по мылу выдает сообщение в чат о скольжении.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
